### PR TITLE
show comments in candidate

### DIFF
--- a/liberime-test.el
+++ b/liberime-test.el
@@ -6,14 +6,9 @@
        ,@body
        (- (float-time) ,start))))
 
-(require 'liberime-core)
-;; darwin
-(setq rime-data-dir "/Library/Input Methods/Squirrel.app/Contents/SharedSupport")
-;; linux
-(setq rime-data-dir "/usr/share/rime-data")
-(require 'liberime-config)
+(let ((liberime-user-data-dir (locate-user-emacs-file "test/rime")))
+  (load "liberime.el"))
 
-(liberime-start rime-data-dir (expand-file-name "~/.emacs.d/test/rime"))
 (liberime-get-schema-list)
 (liberime-select-schema "luna_pinyin_simp")
 (liberime-search "wode" nil)
@@ -23,6 +18,14 @@
 (liberime-get-schema-config "" "speller/auto_select" "bool")
 (liberime-set-schema-config "" "speller/auto_select" true "bool")
 (liberime-sync-user-data)
+
+(defun try-context()
+  (liberime-clear-composition)
+  (liberime-process-key (string-to-char "w"))
+  (liberime-process-key (string-to-char "o"))
+  (liberime-get-context))
+
+(try-context)
 
 (require 'pyim)
 (setq pyim-default-scheme 'quanpin)

--- a/src/init.c
+++ b/src/init.c
@@ -1,6 +1,6 @@
-#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "emacs-module.h"
 #include "interface.h"
@@ -9,16 +9,14 @@
 /* Declare mandatory GPL symbol.  */
 int plugin_is_GPL_compatible;
 
-
-int emacs_module_init (struct emacs_runtime *ert) EMACS_NOEXCEPT
-{
-  emacs_env *env = ert->get_environment (ert);
+int emacs_module_init(struct emacs_runtime *ert) EMACS_NOEXCEPT {
+  emacs_env *env = ert->get_environment(ert);
 
   em_init(env);
 
   liberime_init(env);
 
-  em_provide (env, "liberime-core");
+  em_provide(env, "liberime-core");
 
   /* loaded successfully */
   return 0;

--- a/src/interface.c
+++ b/src/interface.c
@@ -18,12 +18,10 @@ emacs_value em_direct, em_symbolic;
 
 // Symbols that are only reachable from within this file.
 static emacs_value _cons, _defalias, _define_error, _expand_file_name, _rimeerr,
-  _not_implemented, _provide, _user_ptrp, _vector, _wrong_type_argument,
-  _wrong_value_argument, _list;
+    _not_implemented, _provide, _user_ptrp, _vector, _wrong_type_argument,
+    _wrong_value_argument, _list;
 
-
-void em_init(emacs_env *env)
-{
+void em_init(emacs_env *env) {
   em_nil = GLOBREF(INTERN("nil"));
   em_stringp = GLOBREF(INTERN("stringp"));
   em_t = GLOBREF(INTERN("t"));
@@ -56,8 +54,8 @@ void em_init(emacs_env *env)
  * @param nargs The number of arguments that follow.
  * @return The function return value.
  */
-static emacs_value em_funcall(emacs_env *env, emacs_value func, ptrdiff_t nargs, ...)
-{
+static emacs_value em_funcall(emacs_env *env, emacs_value func, ptrdiff_t nargs,
+                              ...) {
   emacs_value args[nargs];
 
   va_list vargs;
@@ -69,79 +67,70 @@ static emacs_value em_funcall(emacs_env *env, emacs_value func, ptrdiff_t nargs,
   return env->funcall(env, func, nargs, args);
 }
 
-bool em_assert(emacs_env *env, emacs_value predicate, emacs_value arg)
-{
+bool em_assert(emacs_env *env, emacs_value predicate, emacs_value arg) {
   bool cond = env->is_not_nil(env, em_funcall(env, predicate, 1, arg));
   if (!cond)
     em_signal_wrong_type(env, predicate, arg);
   return cond;
 }
 
-void em_signal_rimeerr(emacs_env *env, int _klass, const char* _msg)
-{
+void em_signal_rimeerr(emacs_env *env, int _klass, const char *_msg) {
   emacs_value klass = env->make_integer(env, _klass);
   emacs_value msg = env->make_string(env, _msg, strlen(_msg));
-  env->non_local_exit_signal(env, _rimeerr, em_cons(env, klass, em_cons(env, msg, em_nil)));
+  env->non_local_exit_signal(env, _rimeerr,
+                             em_cons(env, klass, em_cons(env, msg, em_nil)));
 }
 
-void em_signal_wrong_type(emacs_env *env, emacs_value expected, emacs_value actual)
-{
+void em_signal_wrong_type(emacs_env *env, emacs_value expected,
+                          emacs_value actual) {
   env->non_local_exit_signal(
-                             env, _wrong_type_argument,
-                             em_cons(env, expected, em_cons(env, actual, em_nil))
-                             );
+      env, _wrong_type_argument,
+      em_cons(env, expected, em_cons(env, actual, em_nil)));
 }
 
-void em_signal_wrong_value(emacs_env *env, emacs_value actual)
-{
+void em_signal_wrong_value(emacs_env *env, emacs_value actual) {
   env->non_local_exit_signal(env, _wrong_value_argument, actual);
 }
 
-char *em_get_string(emacs_env *env, emacs_value arg)
-{
+char *em_get_string(emacs_env *env, emacs_value arg) {
   if (arg == NULL) {
     return NULL;
   } else {
-     ptrdiff_t size;
+    ptrdiff_t size;
     env->copy_string_contents(env, arg, NULL, &size);
 
-    char *buf = (char*) malloc(size * sizeof(char));
+    char *buf = (char *)malloc(size * sizeof(char));
     env->copy_string_contents(env, arg, buf, &size);
 
     return buf;
   }
 }
 
-emacs_value em_cons(emacs_env *env, emacs_value car, emacs_value cdr)
-{
+emacs_value em_cons(emacs_env *env, emacs_value car, emacs_value cdr) {
   return em_funcall(env, _cons, 2, car, cdr);
 }
 
-void em_define_error(emacs_env *env, emacs_value symbol, const char *msg)
-{
-  em_funcall(env, _define_error, 2, symbol, env->make_string(env, msg, strlen(msg)));
+void em_define_error(emacs_env *env, emacs_value symbol, const char *msg) {
+  em_funcall(env, _define_error, 2, symbol,
+             env->make_string(env, msg, strlen(msg)));
 }
 
-void em_defun(emacs_env *env, const char *name, emacs_value func)
-{
+void em_defun(emacs_env *env, const char *name, emacs_value func) {
   em_funcall(env, _defalias, 2, INTERN(name), func);
 }
 
-emacs_value em_expand_file_name(emacs_env *env, emacs_value path)
-{
+emacs_value em_expand_file_name(emacs_env *env, emacs_value path) {
   return em_funcall(env, _expand_file_name, 1, path);
 }
 
-void em_provide(emacs_env *env, const char *feature)
-{
+void em_provide(emacs_env *env, const char *feature) {
   em_funcall(env, _provide, 1, INTERN(feature));
 }
 
-bool em_user_ptrp(emacs_env *env, emacs_value val)
-{
+bool em_user_ptrp(emacs_env *env, emacs_value val) {
   return env->is_not_nil(env, em_funcall(env, _user_ptrp, 1, val));
 }
 
-emacs_value em_list(emacs_env *env, ptrdiff_t array_size, emacs_value* array) {
+emacs_value em_list(emacs_env *env, ptrdiff_t array_size, emacs_value *array) {
   return env->funcall(env, _list, array_size, array);
 }

--- a/src/interface.c
+++ b/src/interface.c
@@ -8,6 +8,8 @@
 #define GLOBREF(val) env->make_global_ref(env, (val))
 #define INTERN(val) env->intern(env, (val))
 
+#define MAX_STRLEN 1024
+
 // We store some globa references to emacs objects, mostly symbols,
 // so that we don't have to waste time calling intern later on.
 
@@ -139,6 +141,18 @@ emacs_value em_list(emacs_env *env, ptrdiff_t array_size, emacs_value *array) {
 emacs_value em_propertize(emacs_env *env, emacs_value target, const char *key,
                           emacs_value value) {
   return em_funcall(env, _propertize, 3, target, INTERN(key), value);
+}
+
+emacs_value em_string(emacs_env *env, char *str) {
+  // always copy string
+  if (str) {
+    size_t size = strnlen(str, MAX_STRLEN);
+    char *new_str = malloc(size + 1);
+    strncpy(new_str, str, size);
+    return env->make_string(env, new_str, size);
+  } else {
+    return em_nil;
+  }
 }
 
 emacs_value em_symbol(emacs_env *env, const char *str) { INTERN(str); }

--- a/src/interface.c
+++ b/src/interface.c
@@ -19,7 +19,7 @@ emacs_value em_direct, em_symbolic;
 // Symbols that are only reachable from within this file.
 static emacs_value _cons, _defalias, _define_error, _expand_file_name, _rimeerr,
     _not_implemented, _provide, _user_ptrp, _vector, _wrong_type_argument,
-    _wrong_value_argument, _list;
+    _wrong_value_argument, _list, _propertize;
 
 void em_init(emacs_env *env) {
   em_nil = GLOBREF(INTERN("nil"));
@@ -41,6 +41,7 @@ void em_init(emacs_env *env) {
   _vector = GLOBREF(INTERN("vector"));
   _wrong_type_argument = GLOBREF(INTERN("wrong-type-argument"));
   _wrong_value_argument = GLOBREF(INTERN("wrong-value-argument"));
+  _propertize = GLOBREF(INTERN("propertize"));
 
   em_define_error(env, _rimeerr, "Rime error");
   em_define_error(env, _not_implemented, "Not implemented");
@@ -134,3 +135,10 @@ bool em_user_ptrp(emacs_env *env, emacs_value val) {
 emacs_value em_list(emacs_env *env, ptrdiff_t array_size, emacs_value *array) {
   return env->funcall(env, _list, array_size, array);
 }
+
+emacs_value em_propertize(emacs_env *env, emacs_value target, const char *key,
+                          emacs_value value) {
+  return em_funcall(env, _propertize, 3, target, INTERN(key), value);
+}
+
+emacs_value em_symbol(emacs_env *env, const char *str) { INTERN(str); }

--- a/src/interface.h
+++ b/src/interface.h
@@ -31,7 +31,7 @@ bool em_assert(emacs_env *env, emacs_value predicate, emacs_value arg);
  * @param _klass The error code.
  * @param _msg The error message.
  */
-void em_signal_rimeerr(emacs_env *env, int _klass, const char* _msg);
+void em_signal_rimeerr(emacs_env *env, int _klass, const char *_msg);
 
 /**
  * Signal a wrong-type-argument error.
@@ -39,7 +39,8 @@ void em_signal_rimeerr(emacs_env *env, int _klass, const char* _msg);
  * @param expected Symbol describing the expected type.
  * @param actual Emacs value that does not have the expected type.
  */
-void em_signal_wrong_type(emacs_env *env, emacs_value expected, emacs_value actual);
+void em_signal_wrong_type(emacs_env *env, emacs_value expected,
+                          emacs_value actual);
 
 /**
  * Signal a wrong-value-argument error.
@@ -50,7 +51,8 @@ void em_signal_wrong_value(emacs_env *env, emacs_value actual);
 
 /**
  * Return a string from an emacs_value.
- * Caller is responsible for ensuring that the value is a string, and to free the returned pointer.
+ * Caller is responsible for ensuring that the value is a string, and to free
+ * the returned pointer.
  * @param env The active Emacs environment.
  * @param arg Emacs value representing a string.
  * @return The string (owned pointer).
@@ -104,7 +106,6 @@ void em_provide(emacs_env *env, const char *feature);
  */
 bool em_user_ptrp(emacs_env *env, emacs_value val);
 
-
-emacs_value em_list(emacs_env *env, ptrdiff_t array_size, emacs_value* array);
+emacs_value em_list(emacs_env *env, ptrdiff_t array_size, emacs_value *array);
 
 #endif /* INTERFACE_H */

--- a/src/interface.h
+++ b/src/interface.h
@@ -106,6 +106,31 @@ void em_provide(emacs_env *env, const char *feature);
  */
 bool em_user_ptrp(emacs_env *env, emacs_value val);
 
-emacs_value em_list(emacs_env *env, ptrdiff_t array_size, emacs_value *array);
+/**
+ * make a Emacs list with array
+ * @param env the active Emacs enviroment.
+ * @param size size of the array.
+ * @param array pointer.
+ * @return emacs_value represent the list.
+ */
+emacs_value em_list(emacs_env *env, ptrdiff_t size, emacs_value *array);
+
+/**
+ * propertize the value
+ * @param env the active Emacs enviroment.
+ * @param target the propertize target.
+ * @param key property key.
+ * @param value property value.
+ * @return propertized value of param value.
+ */
+emacs_value em_propertize(emacs_env *env, emacs_value target, const char *key,
+                          emacs_value value);
+/**
+ * make a Emacs symbol with string.
+ * @param env the active Emacs enviroment.
+ * @param str string that to be a symbol.
+ * @return emacs_value represents a symbol.
+ */
+emacs_value em_symbol(emacs_env *env, const char *str);
 
 #endif /* INTERFACE_H */

--- a/src/interface.h
+++ b/src/interface.h
@@ -133,4 +133,12 @@ emacs_value em_propertize(emacs_env *env, emacs_value target, const char *key,
  */
 emacs_value em_symbol(emacs_env *env, const char *str);
 
+/**
+ * make a Emacs string with string, always copy it, so it's safe to free *src.
+ * @param env the active Emacs enviroment.
+ * @param str string that to be convert to emacs string.
+ * @return emacs_value represents a emacs string.
+ */
+emacs_value em_string(emacs_env *env, char *str);
+
 #endif /* INTERFACE_H */

--- a/src/liberime-core.c
+++ b/src/liberime-core.c
@@ -499,11 +499,9 @@ static emacs_value get_context(emacs_env *env, ptrdiff_t nargs,
     for (int i = 0; i < context.menu.num_candidates; i++) {
       RimeCandidate candidate = context.menu.candidates[i];
 
-      emacs_value value =
-          env->make_string(env, candidate.text, strlen(candidate.text));
+      emacs_value value = em_string(env, candidate.text);
       if (candidate.comment) {
-        emacs_value comment =
-            env->make_string(env, candidate.comment, strlen(candidate.comment));
+        emacs_value comment = em_string(env, candidate.comment);
         value = em_propertize(env, value, ":comment", comment);
       }
 

--- a/src/liberime-core.c
+++ b/src/liberime-core.c
@@ -1,9 +1,8 @@
-#include <stdbool.h>
-#include <stdlib.h>
+#include <rime_api.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
-#include <rime_api.h>
 
 #include <unistd.h>
 
@@ -16,31 +15,28 @@
  * @param args The argument list as visible from Emacs (without parens).
  * @param docstring The rest of the documentation.
  */
-#define DOCSTRING(name, args, docstring)                                \
-const char *liberime_##name##__doc = (docstring "\n\n(fn " args ")")
+#define DOCSTRING(name, args, docstring)                                       \
+  const char *liberime_##name##__doc = (docstring "\n\n(fn " args ")")
 
-#define DEFUN(ename, cname, min_nargs, max_nargs)                       \
-  em_defun(env, (ename),                                                \
-           env->make_function(env, (min_nargs), (max_nargs),            \
-                              cname,                                    \
-                              liberime_##cname##__doc,                  \
-                              rime))
+#define DEFUN(ename, cname, min_nargs, max_nargs)                              \
+  em_defun(env, (ename),                                                       \
+           env->make_function(env, (min_nargs), (max_nargs), cname,            \
+                              liberime_##cname##__doc, rime))
 
-#define CONS_INT(key, integer)                                          \
+#define CONS_INT(key, integer)                                                 \
   em_cons(env, env->intern(env, key), env->make_integer(env, integer));
-#define CONS_STRING(key, str)                                           \
+#define CONS_STRING(key, str)                                                  \
   em_cons(env, env->intern(env, key), env->make_string(env, str, strlen(str)))
-#define CONS_NIL(key) \
-  em_cons(env, env->intern(env, key), em_nil)
-#define CONS_VALUE(key, value)                  \
-  em_cons(env, env->intern(env, key), value)
+#define CONS_NIL(key) em_cons(env, env->intern(env, key), em_nil)
+#define CONS_VALUE(key, value) em_cons(env, env->intern(env, key), value)
 
 #define CANDIDATE_MAXSTRLEN 1024
 #define SCHEMA_MAXSTRLEN 1024
 #define CONFIG_MAXSTRLEN 1024
 #define INPUT_MAXSTRLEN 1024
 
-#define NO_SESSION_ERR "Cannot connect to librime session, make sure to run liberime-start first."
+#define NO_SESSION_ERR                                                         \
+  "Cannot connect to librime session, make sure to run liberime-start first."
 
 typedef struct _EmacsRime {
   RimeSessionId session_id;
@@ -58,17 +54,18 @@ typedef struct _EmacsRimeCandidates {
   CandidateLinkedList *list;
 } EmacsRimeCandidates;
 
-void notification_handler(void *context,
-                          RimeSessionId session_id,
-                          const char *message_type,
-                          const char *message_value) {
+void notification_handler(void *context, RimeSessionId session_id,
+                          const char *message_type, const char *message_value) {
   /* EmacsRime *rime = (EmacsRime*) context; */
   /* emacs_env *env = rime->EmacsEnv; */
   /* char format[] = "[liberime] %s: %s"; */
   /* emacs_value args[3]; */
-  /* args[0] = env->make_string(env, format, strnlen(format, SCHEMA_MAXSTRLEN)); */
-  /* args[1] = env->make_string(env, message_type, strnlen(message_type, SCHEMA_MAXSTRLEN)); */
-  /* args[2] = env->make_string(env, message_value, strnlen(message_value, SCHEMA_MAXSTRLEN)); */
+  /* args[0] = env->make_string(env, format, strnlen(format, SCHEMA_MAXSTRLEN));
+   */
+  /* args[1] = env->make_string(env, message_type, strnlen(message_type,
+   * SCHEMA_MAXSTRLEN)); */
+  /* args[2] = env->make_string(env, message_value, strnlen(message_value,
+   * SCHEMA_MAXSTRLEN)); */
   /* env->funcall(env, env->intern (env, "message"), 3, args); */
 }
 
@@ -86,23 +83,26 @@ static bool _ensure_session(EmacsRime *rime) {
 
 static char *_copy_string(char *str) {
   if (str) {
-     size_t size = strnlen(str, CANDIDATE_MAXSTRLEN);
-     char *new_str = malloc(size+1);
-     strncpy(new_str, str, size);
-     new_str[size] = '\0';
-     return new_str;
+    size_t size = strnlen(str, CANDIDATE_MAXSTRLEN);
+    char *new_str = malloc(size + 1);
+    strncpy(new_str, str, size);
+    new_str[size] = '\0';
+    return new_str;
   } else {
     return NULL;
   }
 }
 
 EmacsRimeCandidates _get_candidates(EmacsRime *rime, size_t limit) {
-  EmacsRimeCandidates c = {.size=0, .list=(CandidateLinkedList *)malloc(sizeof(CandidateLinkedList))};
+  EmacsRimeCandidates c = {
+      .size = 0,
+      .list = (CandidateLinkedList *)malloc(sizeof(CandidateLinkedList))};
 
   RimeCandidateListIterator iterator = {0};
   CandidateLinkedList *next = c.list;
   if (rime->api->candidate_list_begin(rime->session_id, &iterator)) {
-    while (rime->api->candidate_list_next(&iterator) && (limit == 0 || c.size < limit)) {
+    while (rime->api->candidate_list_next(&iterator) &&
+           (limit == 0 || c.size < limit)) {
       c.size += 1;
 
       next->value = _copy_string(iterator.candidate.text);
@@ -118,10 +118,10 @@ EmacsRimeCandidates _get_candidates(EmacsRime *rime, size_t limit) {
 }
 
 // bindings
-DOCSTRING(start, "SHARED_DATA_DIR USER_DATA_DIR",
-          "Start a rime session.");
-static emacs_value start(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+DOCSTRING(start, "SHARED_DATA_DIR USER_DATA_DIR", "Start a rime session.");
+static emacs_value start(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
+                         void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   char *shared_data_dir = em_get_string(env, em_expand_file_name(env, args[0]));
   char *user_data_dir = em_get_string(env, em_expand_file_name(env, args[1]));
@@ -152,8 +152,9 @@ static emacs_value start(emacs_env *env, ptrdiff_t nargs, emacs_value args[], vo
 }
 
 DOCSTRING(finalize, "", "Finalize librime for redeploy.");
-static emacs_value finalize(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value finalize(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
+                            void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
   if (rime->session_id) {
     rime->session_id = 0;
   }
@@ -178,9 +179,10 @@ void free_candidate_list(CandidateLinkedList *list) {
 DOCSTRING(search, "STRING &optional LIMIT",
           "Input STRING and return LIMIT number candidates.\n"
           "When LIMIT is nil, return all candidates.");
-static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
-  char* string = em_get_string(env, args[0]);
+static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
+                          void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
+  char *string = em_get_string(env, args[0]);
 
   size_t limit = 0;
   if (nargs == 2) {
@@ -211,7 +213,7 @@ static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[], v
     return em_nil;
   }
 
-  emacs_value* array = malloc(sizeof(emacs_value) * candidates.size);
+  emacs_value *array = malloc(sizeof(emacs_value) * candidates.size);
 
   CandidateLinkedList *next = candidates.list;
   int i = 0;
@@ -234,8 +236,9 @@ static emacs_value search(emacs_env *env, ptrdiff_t nargs, emacs_value args[], v
 }
 
 DOCSTRING(get_sync_dir, "", "Get rime sync directory.");
-static emacs_value get_sync_dir(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value get_sync_dir(emacs_env *env, ptrdiff_t nargs,
+                                emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
     return em_nil;
@@ -246,8 +249,9 @@ static emacs_value get_sync_dir(emacs_env *env, ptrdiff_t nargs, emacs_value arg
 }
 
 DOCSTRING(sync_user_data, "", "Sync rime user data.");
-static emacs_value sync_user_data(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value sync_user_data(emacs_env *env, ptrdiff_t nargs,
+                                  emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
     return em_nil;
@@ -258,8 +262,9 @@ static emacs_value sync_user_data(emacs_env *env, ptrdiff_t nargs, emacs_value a
 }
 
 DOCSTRING(get_schema_list, "", "List all rime schema.");
-static emacs_value get_schema_list(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value get_schema_list(emacs_env *env, ptrdiff_t nargs,
+                                   emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
     return em_nil;
@@ -276,8 +281,10 @@ static emacs_value get_schema_list(emacs_env *env, ptrdiff_t nargs, emacs_value 
   for (int i = 0; i < schema_list.size; i++) {
     RimeSchemaListItem item = schema_list.list[i];
     emacs_value pair[2];
-    pair[0] = env->make_string(env, item.schema_id, strnlen(item.schema_id, SCHEMA_MAXSTRLEN));
-    pair[1] = env->make_string(env, item.name, strnlen(item.name, SCHEMA_MAXSTRLEN));
+    pair[0] = env->make_string(env, item.schema_id,
+                               strnlen(item.schema_id, SCHEMA_MAXSTRLEN));
+    pair[1] =
+        env->make_string(env, item.name, strnlen(item.name, SCHEMA_MAXSTRLEN));
 
     array[i] = env->funcall(env, flist, 2, pair);
   }
@@ -289,11 +296,13 @@ static emacs_value get_schema_list(emacs_env *env, ptrdiff_t nargs, emacs_value 
   return result;
 }
 
-DOCSTRING(select_schema, "SCHEMA_ID",
-            "Select a rime schema.\n"
-            "SCHENA_ID should be a value returned from `liberime-get-schema-list'.");
-static emacs_value select_schema(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+DOCSTRING(
+    select_schema, "SCHEMA_ID",
+    "Select a rime schema.\n"
+    "SCHENA_ID should be a value returned from `liberime-get-schema-list'.");
+static emacs_value select_schema(emacs_env *env, ptrdiff_t nargs,
+                                 emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
   const char *schema_id = em_get_string(env, args[0]);
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -307,9 +316,11 @@ static emacs_value select_schema(emacs_env *env, ptrdiff_t nargs, emacs_value ar
 }
 
 // input
-DOCSTRING(process_key, "KEYCODE &optional MASK", "Send KEYCODE to rime session and process it.");
-static emacs_value process_key(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+DOCSTRING(process_key, "KEYCODE &optional MASK",
+          "Send KEYCODE to rime session and process it.");
+static emacs_value process_key(emacs_env *env, ptrdiff_t nargs,
+                               emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   int keycode = env->extract_integer(env, args[0]);
   int mask = 0;
@@ -329,15 +340,16 @@ static emacs_value process_key(emacs_env *env, ptrdiff_t nargs, emacs_value args
 }
 
 DOCSTRING(get_input, "", "Get rime input.");
-static emacs_value get_input(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value get_input(emacs_env *env, ptrdiff_t nargs,
+                             emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
     return em_nil;
   }
 
-  const char* input = rime->api->get_input(rime->session_id);
+  const char *input = rime->api->get_input(rime->session_id);
 
   if (!input) {
     return em_nil;
@@ -347,8 +359,9 @@ static emacs_value get_input(emacs_env *env, ptrdiff_t nargs, emacs_value args[]
 }
 
 DOCSTRING(commit_composition, "", "Commit rime composition.");
-static emacs_value commit_composition(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value commit_composition(emacs_env *env, ptrdiff_t nargs,
+                                      emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -362,8 +375,9 @@ static emacs_value commit_composition(emacs_env *env, ptrdiff_t nargs, emacs_val
 }
 
 DOCSTRING(clear_composition, "", "Clear rime composition.");
-static emacs_value clear_composition(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value clear_composition(emacs_env *env, ptrdiff_t nargs,
+                                     emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -375,8 +389,9 @@ static emacs_value clear_composition(emacs_env *env, ptrdiff_t nargs, emacs_valu
 }
 
 DOCSTRING(select_candidate, "NUM", "Select a rime candidate by NUM.");
-static emacs_value select_candidate(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value select_candidate(emacs_env *env, ptrdiff_t nargs,
+                                    emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   int index = env->extract_integer(env, args[0]);
 
@@ -389,8 +404,9 @@ static emacs_value select_candidate(emacs_env *env, ptrdiff_t nargs, emacs_value
 // output
 
 DOCSTRING(get_commit, "", "Get rime commit.");
-static emacs_value get_commit(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value get_commit(emacs_env *env, ptrdiff_t nargs,
+                              emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -414,8 +430,9 @@ static emacs_value get_commit(emacs_env *env, ptrdiff_t nargs, emacs_value args[
 }
 
 DOCSTRING(get_context, "", "Get rime context.");
-static emacs_value get_context(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value get_context(emacs_env *env, ptrdiff_t nargs,
+                               emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -423,7 +440,7 @@ static emacs_value get_context(emacs_env *env, ptrdiff_t nargs, emacs_value args
   }
 
   RIME_STRUCT(RimeContext, context);
-  if (!rime->api->get_context(rime->session_id, &context)){
+  if (!rime->api->get_context(rime->session_id, &context)) {
     em_signal_rimeerr(env, 2, "Cannot get context.");
     return em_nil;
   }
@@ -453,17 +470,20 @@ static emacs_value get_context(emacs_env *env, ptrdiff_t nargs, emacs_value args
     // When we don't have a preedit,
     // The composition should be nil.
     return em_nil;
-    /* composition_array[4] = CONS_NIL("preedit"); */
+  /* composition_array[4] = CONS_NIL("preedit"); */
 
-  emacs_value composition_value = em_list(env, composition_size, composition_array);
+  emacs_value composition_value =
+      em_list(env, composition_size, composition_array);
   result_array[1] = CONS_VALUE("composition", composition_value);
 
   // 3. context.menu
   if (context.menu.num_candidates) {
     size_t menu_size = 6;
     emacs_value menu_array[menu_size];
-    menu_array[0] = CONS_INT("highlighted-candidate-index", context.menu.highlighted_candidate_index);
-    menu_array[1] = CONS_VALUE("last-page-p", context.menu.is_last_page ? em_t : em_nil);
+    menu_array[0] = CONS_INT("highlighted-candidate-index",
+                             context.menu.highlighted_candidate_index);
+    menu_array[1] =
+        CONS_VALUE("last-page-p", context.menu.is_last_page ? em_t : em_nil);
     menu_array[2] = CONS_INT("num-candidates", context.menu.num_candidates);
     menu_array[3] = CONS_INT("page-no", context.menu.page_no);
     menu_array[4] = CONS_INT("page-size", context.menu.page_size);
@@ -491,8 +511,9 @@ static emacs_value get_context(emacs_env *env, ptrdiff_t nargs, emacs_value args
 }
 
 DOCSTRING(get_status, "", "Get rime status.");
-static emacs_value get_status(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value get_status(emacs_env *env, ptrdiff_t nargs,
+                              emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -500,7 +521,7 @@ static emacs_value get_status(emacs_env *env, ptrdiff_t nargs, emacs_value args[
   }
 
   RIME_STRUCT(RimeStatus, status);
-  if (!rime->api->get_status(rime->session_id, &status)){
+  if (!rime->api->get_status(rime->session_id, &status)) {
     em_signal_rimeerr(env, 2, "Cannot get status.");
     return em_nil;
   }
@@ -520,13 +541,20 @@ static emacs_value get_status(emacs_env *env, ptrdiff_t nargs, emacs_value args[
   else
     result_array[1] = CONS_NIL("schema_name");
 
-  result_array[2] = CONS_VALUE("is_disabled", status.is_disabled ? em_t : em_nil);
-  result_array[3] = CONS_VALUE("is_composing", status.is_composing ? em_t : em_nil);
-  result_array[4] = CONS_VALUE("is_ascii_mode", status.is_ascii_mode ? em_t : em_nil);
-  result_array[5] = CONS_VALUE("is_full_shape", status.is_full_shape ? em_t : em_nil);
-  result_array[6] = CONS_VALUE("is_simplified", status.is_simplified ? em_t : em_nil);
-  result_array[7] = CONS_VALUE("is_traditional", status.is_traditional ? em_t : em_nil);
-  result_array[8] = CONS_VALUE("is_ascii_punct", status.is_ascii_punct ? em_t : em_nil);
+  result_array[2] =
+      CONS_VALUE("is_disabled", status.is_disabled ? em_t : em_nil);
+  result_array[3] =
+      CONS_VALUE("is_composing", status.is_composing ? em_t : em_nil);
+  result_array[4] =
+      CONS_VALUE("is_ascii_mode", status.is_ascii_mode ? em_t : em_nil);
+  result_array[5] =
+      CONS_VALUE("is_full_shape", status.is_full_shape ? em_t : em_nil);
+  result_array[6] =
+      CONS_VALUE("is_simplified", status.is_simplified ? em_t : em_nil);
+  result_array[7] =
+      CONS_VALUE("is_traditional", status.is_traditional ? em_t : em_nil);
+  result_array[8] =
+      CONS_VALUE("is_ascii_punct", status.is_ascii_punct ? em_t : em_nil);
 
   // build result
   emacs_value result = em_list(env, result_size, result_array);
@@ -536,12 +564,12 @@ static emacs_value get_status(emacs_env *env, ptrdiff_t nargs, emacs_value args[
   return result;
 }
 
-
 DOCSTRING(get_user_config, "USER-CONFIG OPTION &optional RETURN-VALUE-TYPE",
           "Get OPTION of rime USER-CONFIG.\n"
           "The return value type can be set with RETURN-VALUE-TYPE.");
-static emacs_value get_user_config(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value get_user_config(emacs_env *env, ptrdiff_t nargs,
+                                   emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -563,8 +591,8 @@ static emacs_value get_user_config(emacs_env *env, ptrdiff_t nargs, emacs_value 
   RimeConfig *config = malloc(sizeof(RimeConfig));
   // 注意user_config_open是从user_data_dir下获取
   if (!rime->api->user_config_open(config_id, config)) {
-        em_signal_rimeerr(env, 2, "Failed to open user config file.");
-      return em_nil;
+    em_signal_rimeerr(env, 2, "Failed to open user config file.");
+    return em_nil;
   }
 
   bool success = false;
@@ -600,8 +628,9 @@ static emacs_value get_user_config(emacs_env *env, ptrdiff_t nargs, emacs_value 
 DOCSTRING(set_user_config, "USER-CONFIG OPTION VALUE &optional VALUE-TYPE",
           "Set rime USER-CONFIG OPTION to VALUE.\n"
           "When VALUE-TYPE is non-nil, VALUE will be converted to this type.");
-static emacs_value set_user_config(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value set_user_config(emacs_env *env, ptrdiff_t nargs,
+                                   emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -643,12 +672,12 @@ static emacs_value set_user_config(emacs_env *env, ptrdiff_t nargs, emacs_value 
   return em_t;
 }
 
-
 DOCSTRING(get_schema_config, "SCHEMA-CONFIG OPTION &optional RETURN-VALUE-TYPE",
           "Get OPTION of rime SCHEMA-CONFIG.\n"
           "The return value type can be set with RETURN-VALUE-TYPE.");
-static emacs_value get_schema_config(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value get_schema_config(emacs_env *env, ptrdiff_t nargs,
+                                     emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -660,14 +689,15 @@ static emacs_value get_schema_config(emacs_env *env, ptrdiff_t nargs, emacs_valu
     return em_nil;
   }
 
-  const char *arg0  = em_get_string(env, args[0]);
+  const char *arg0 = em_get_string(env, args[0]);
   const int max_schema_length = 0xff;
   char *schema_id = (char *)malloc(max_schema_length * sizeof(char));
   memset(schema_id, 0, max_schema_length);
-    if (arg0 == NULL || strlen(arg0) == 0) {
-        if (!rime->api->get_current_schema(rime->session_id, schema_id, max_schema_length)) {
-        em_signal_rimeerr(env, 2, "error get current schema");
-        return em_nil;
+  if (arg0 == NULL || strlen(arg0) == 0) {
+    if (!rime->api->get_current_schema(rime->session_id, schema_id,
+                                       max_schema_length)) {
+      em_signal_rimeerr(env, 2, "error get current schema");
+      return em_nil;
     }
   } else {
     if (strlen(arg0) > max_schema_length) {
@@ -692,9 +722,9 @@ static emacs_value get_schema_config(emacs_env *env, ptrdiff_t nargs, emacs_valu
 
   RimeConfig *config = malloc(sizeof(RimeConfig));
   if (!rime->api->schema_open(schema_id, config)) {
-      free(schema_id);
-      em_signal_rimeerr(env, 2, "Failed to open schema config file.");
-      return em_nil;
+    free(schema_id);
+    em_signal_rimeerr(env, 2, "Failed to open schema config file.");
+    return em_nil;
   }
 
   free(schema_id);
@@ -732,8 +762,9 @@ static emacs_value get_schema_config(emacs_env *env, ptrdiff_t nargs, emacs_valu
 DOCSTRING(set_schema_config, "CONFIG OPTION VALUE &optional VALUE-TYPE",
           "Set rime SCHEMA-CONFIG OPTION to VALUE.\n"
           "When VALUE-TYPE is non-nil, VALUE will be converted to this type.");
-static emacs_value set_schema_config(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data) {
-  EmacsRime *rime = (EmacsRime*) data;
+static emacs_value set_schema_config(emacs_env *env, ptrdiff_t nargs,
+                                     emacs_value args[], void *data) {
+  EmacsRime *rime = (EmacsRime *)data;
 
   if (!_ensure_session(rime)) {
     em_signal_rimeerr(env, 1, NO_SESSION_ERR);
@@ -743,14 +774,15 @@ static emacs_value set_schema_config(emacs_env *env, ptrdiff_t nargs, emacs_valu
     em_signal_rimeerr(env, 2, "Invalid arguments.");
   }
 
-  const char *arg0  = em_get_string(env, args[0]);
+  const char *arg0 = em_get_string(env, args[0]);
   const int max_schema_length = 0xff;
   char *schema_id = (char *)malloc(max_schema_length * sizeof(char));
   memset(schema_id, 0, max_schema_length);
-    if (arg0 == NULL || strlen(arg0) == 0) {
-        if (!rime->api->get_current_schema(rime->session_id, schema_id, max_schema_length)) {
-        em_signal_rimeerr(env, 2, "Error get current schema.");
-        return em_nil;
+  if (arg0 == NULL || strlen(arg0) == 0) {
+    if (!rime->api->get_current_schema(rime->session_id, schema_id,
+                                       max_schema_length)) {
+      em_signal_rimeerr(env, 2, "Error get current schema.");
+      return em_nil;
     }
   } else {
     if (strlen(arg0) > max_schema_length) {
@@ -776,9 +808,9 @@ static emacs_value set_schema_config(emacs_env *env, ptrdiff_t nargs, emacs_valu
 
   RimeConfig *config = (RimeConfig *)malloc(sizeof(RimeConfig));
   if (!rime->api->schema_open(schema_id, config)) {
-      free(schema_id);
-      em_signal_rimeerr(env, 2, "Failed to open schema config file.");
-      return em_nil;
+    free(schema_id);
+    em_signal_rimeerr(env, 2, "Failed to open schema config file.");
+    return em_nil;
   }
 
   free(schema_id);
@@ -803,7 +835,7 @@ static emacs_value set_schema_config(emacs_env *env, ptrdiff_t nargs, emacs_valu
 void liberime_init(emacs_env *env) {
   // Name 'rime' is hardcode in DEFUN micro, so if you edit here,
   // you should edit DEFUN micro too.
-  EmacsRime *rime = (EmacsRime*) malloc(sizeof(EmacsRime));
+  EmacsRime *rime = (EmacsRime *)malloc(sizeof(EmacsRime));
 
   rime->api = rime_get_api();
   rime->first_run = true; // not used yet

--- a/src/liberime-core.h
+++ b/src/liberime-core.h
@@ -1,5 +1,5 @@
-#include <stdbool.h>
 #include <rime_api.h>
+#include <stdbool.h>
 
 #include "emacs-module.h"
 


### PR DESCRIPTION
最近在研究 [rime 输入 emoji 方案](https://github.com/rime/rime-emoji)的时候发现之前一直忽略掉了 rime candidate 的 comment，这个应该是在某些方案配置之后显示的一些重要信息（比如拼音反查，以及这里 emoji 含义的显示等）。所以感觉还是有必要加上的。

![image](https://user-images.githubusercontent.com/1495875/78771526-defd9b00-79c2-11ea-93dc-7f6439eca430.png)

这里直接把 comment 拼在了 candidate 后面， @tumashu 这样会影响到 pyim 吗？