### PR TITLE
liberime-select-schema check schema_id exists

### DIFF
--- a/liberime.el
+++ b/liberime.el
@@ -114,7 +114,7 @@ if NAMES is nil, \"rime-data\" as fallback."
   (or liberime-shared-data-dir
       ;; Guess
       (cl-case system-type
-        ('gnu/linux
+        (gnu/linux
          (liberime-find-rime-data
           '("/usr/share/local"
             "/usr/share"
@@ -122,9 +122,9 @@ if NAMES is nil, \"rime-data\" as fallback."
             "~/.guix-home/profile/share"
             "~/.guix-profile/share"
             "/run/current-system/profile/share")))
-        ('darwin
+        (darwin
          "/Library/Input Methods/Squirrel.app/Contents/SharedSupport")
-        ('windows-nt
+        (windows-nt
          (liberime-find-rime-data
           (list
            (let ((file (executable-find "emacs")))
@@ -143,7 +143,7 @@ if NAMES is nil, \"rime-data\" as fallback."
   "Return user data directory, create it if necessary."
   (let ((directory (expand-file-name liberime-user-data-dir)))
     (unless (file-directory-p directory)
-      (make-directory directory))
+      (make-directory directory t))
     directory))
 
 (declare-function w32-shell-execute "w32fns")

--- a/src/liberime-core.c
+++ b/src/liberime-core.c
@@ -386,12 +386,32 @@ static emacs_value select_schema(emacs_env *env, ptrdiff_t nargs,
     return em_nil;
   }
 
-  bool result = rime->api->select_schema(rime->session_id, schema_id);
-  free((char *)schema_id);
+  RimeSchemaList schema_list;
+  if (!rime->api->get_schema_list(&schema_list)) {
+    em_signal_rimeerr(env, 1, "Get schema list from librime failed.");
+    free((char *)schema_id);
+    return em_nil;
+  }
 
-  if (result) {
+  bool found = false;
+  for (int i = 0; i < schema_list.size; i++) {
+    if (strcmp(schema_list.list[i].schema_id, schema_id) == 0) {
+      found = true;
+      break;
+    }
+  }
+  rime->api->free_schema_list(&schema_list);
+
+  if (!found) {
+    free((char *)schema_id);
+    return em_nil;
+  }
+
+  if (rime->api->select_schema(rime->session_id, schema_id)) {
+    free((char *)schema_id);
     return em_t;
   }
+  free((char *)schema_id);
   return em_nil;
 }
 


### PR DESCRIPTION
Add validation to check if the schema_id exists in the schema list before selecting it. This prevents selecting non-existent schemas.