### PR TITLE
指明需作为依赖分发的dll

### DIFF
--- a/tools/liberime-msys2-build.sh
+++ b/tools/liberime-msys2-build.sh
@@ -112,6 +112,26 @@ function archive_liberime() {
         install_all_dll ${MINGW_PREFIX}/bin/librime-1.dll    \
                         ${archive_dir}/bin/                   \
                         "mingw32/bin\\|mingw32/lib\\|mingw64/bin\\|mingw64/lib\\|usr/bin\\|usr/lib"
+        # 额外确保以下动态库被包含
+        local extra_deps=(
+            libcapnp.dll
+            lua55.dll
+            libglog-2.dll
+            libkj.dll
+            libyaml-cpp.dll
+            libopencc-1.3.dll
+            libmarisa-0.dll
+            libleveldb.dll
+            libunwind.dll
+        )
+        for dep in "${extra_deps[@]}"; do
+            local dep_path="${MINGW_PREFIX}/bin/${dep}"
+            if [[ -f "${dep_path}" ]]; then
+                install -Dm644 "${dep_path}" -t "${archive_dir}/bin/"
+            else
+                echo "警告: 未找到 ${dep_path}，跳过"
+            fi
+        done
         install -Dm644 ${INSTALL_PREFIX}/lib/librime* -t ${archive_dir}/lib/
         install -Dm644 ${INSTALL_PREFIX}/include/rime* -t ${archive_dir}/include/
         install -Dm644 ${INSTALL_PREFIX}/share/opencc/* -t ${archive_dir}/share/rime-data/opencc/


### PR DESCRIPTION
这里的librime为我添加了[更新配方](https://github.com/msys2/MINGW-packages/pull/29702)后支持默认4插件（`librime-lua`, `librime-octagram`, `librime-predict` 和 `librime-proto`）的版本。

由于引入了新的依赖，因此指明了 `librime-1.dll` 依赖且没有随windows版emacs一起分发的那些DLL，一并打包以供发布。